### PR TITLE
More predictable behaviour when using destination view

### DIFF
--- a/KLCPopup/KLCPopup.h
+++ b/KLCPopup/KLCPopup.h
@@ -21,6 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 // KLCPopupShowType: Controls how the popup will be presented.
 typedef NS_ENUM(NSInteger, KLCPopupShowType) {

--- a/KLCPopup/KLCPopup.m
+++ b/KLCPopup/KLCPopup.m
@@ -529,18 +529,21 @@ const KLCPopupLayout KLCPopupLayoutCenter = { KLCPopupHorizontalLayoutCenter, KL
     [self willStartShowing];
     
     dispatch_async( dispatch_get_main_queue(), ^{
-      
-      // Prepare by adding to the top window.
-      if(!self.superview){
-        NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication] windows] reverseObjectEnumerator];
-        
-        for (UIWindow *window in frontToBackWindows) {
-          if (window.windowLevel == UIWindowLevelNormal) {
-            [window addSubview:self];
-            
-            break;
-          }
+      UIView* destView;
+      if(!self.superview) {
+        destView = [parameters valueForKey:@"view"];
+        if (destView == nil) {
+            // Prepare by adding to the top window.
+            NSEnumerator *frontToBackWindows = [[[UIApplication sharedApplication] windows] reverseObjectEnumerator];
+
+            for (UIWindow *window in frontToBackWindows)
+              if (window.windowLevel == UIWindowLevelNormal) {
+                  destView = window;
+                  break;
+              }
         }
+        [destView addSubview:self];
+        [destView bringSubviewToFront:self];
       }
       
       // Before we calculate layout for containerView, make sure we are transformed for current orientation.
@@ -647,9 +650,8 @@ const KLCPopupLayout KLCPopupLayoutCenter = { KLCPopupHorizontalLayoutCenter, KL
         CGPoint centerInSelf;
         
         // Convert coordinates from provided view to self. Otherwise use as-is.
-        UIView* fromView = [parameters valueForKey:@"view"];
-        if (fromView != nil) {
-          centerInSelf = [self convertPoint:centerInView fromView:fromView];
+        if (destView != nil) {
+          centerInSelf = [self convertPoint:centerInView fromView:destView];
         } else {
           centerInSelf = centerInView;
         }


### PR DESCRIPTION
Created a brunch to fix this issues [One](https://github.com/jmascia/KLCPopup/issues/25), [Two](https://github.com/jmascia/KLCPopup/issues/39).

Now when you show popup in view with center it adds the popup as the subview to that view, not as window's subview.
